### PR TITLE
[AT-001] - Implementa AppCoordinator e protocolo Coordinator

### DIFF
--- a/AutoTrackApp.xcodeproj/xcuserdata/lucrodrigs.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AutoTrackApp.xcodeproj/xcuserdata/lucrodrigs.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "F5CDE949-4D36-425E-8C2B-AC3209BE27CA"
+   type = "1"
+   version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "DD03B0C8-7B8E-4448-83C1-0DFAE522BFA2"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AutoTrackApp/Main/Login/View/LoginViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "24"
+            endingLineNumber = "24"
+            landmarkName = "viewDidLoad()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
+</Bucket>

--- a/AutoTrackApp.xcodeproj/xcuserdata/lucrodrigs.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AutoTrackApp.xcodeproj/xcuserdata/lucrodrigs.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "F5CDE949-4D36-425E-8C2B-AC3209BE27CA"
    type = "1"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "DD03B0C8-7B8E-4448-83C1-0DFAE522BFA2"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "AutoTrackApp/Main/Login/View/LoginViewController.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "24"
-            endingLineNumber = "24"
-            landmarkName = "viewDidLoad()"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/AutoTrackApp/AppCoordinator.swift
+++ b/AutoTrackApp/AppCoordinator.swift
@@ -6,32 +6,25 @@
 //
 
 import Foundation
+import UIKit
 
-class AppCoordinator: Coordinator {
+class AppCoordinator {
+    
     let window: UIWindow
     
     var childCoordinator: Coordinator?
-    var viewController: UIViewController!
     var navigationController: UINavigationController?
     
     init(_ window: UIWindow) {
         self.window = window
-        self.window.makeKeyAndVisible()
     }
     
-    func startCoordinator() {
-        //TODO: implementar regra para inicialização do app (flow login)
-        ///basicamente a tela de login sera responsavel por varias partes da regra de inicialização do app
-        ///tera a regra de negocio para saber se o cliente ja esta logado e ir direto para a home
-        ///tera a regra de negocio para saber se o cliente nao esta logado e ir para a tela de login
-        ///apos a implementacao da regra, ao iniciar a tela da home ele precisa alterar a root da navigation para a home
+    func start(using navigationController: UINavigationController) {
+        self.navigationController = navigationController
         
-        let viewController = ATTabBarController()
-        let navigationController = UINavigationController(rootViewController: viewController)
-        self.viewController = viewController
-        
-        self.window.rootViewController = navigationController
-        self.window.makeKeyAndVisible()
+        let loginCoordinator = LoginCoordinator()
+        childCoordinator = loginCoordinator
+        childCoordinator?.start(using: navigationController)
     }
     
 }

--- a/AutoTrackApp/AppCoordinator.swift
+++ b/AutoTrackApp/AppCoordinator.swift
@@ -1,0 +1,37 @@
+//
+//  AppCoordinator.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation
+
+class AppCoordinator: Coordinator {
+    let window: UIWindow
+    
+    var childCoordinator: Coordinator?
+    var viewController: UIViewController!
+    var navigationController: UINavigationController?
+    
+    init(_ window: UIWindow) {
+        self.window = window
+        self.window.makeKeyAndVisible()
+    }
+    
+    func startCoordinator() {
+        //TODO: implementar regra para inicialização do app (flow login)
+        ///basicamente a tela de login sera responsavel por varias partes da regra de inicialização do app
+        ///tera a regra de negocio para saber se o cliente ja esta logado e ir direto para a home
+        ///tera a regra de negocio para saber se o cliente nao esta logado e ir para a tela de login
+        ///apos a implementacao da regra, ao iniciar a tela da home ele precisa alterar a root da navigation para a home
+        
+        let viewController = ATTabBarController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        self.viewController = viewController
+        
+        self.window.rootViewController = navigationController
+        self.window.makeKeyAndVisible()
+    }
+    
+}

--- a/AutoTrackApp/Commons/AppCoordinator.swift
+++ b/AutoTrackApp/Commons/AppCoordinator.swift
@@ -1,8 +1,0 @@
-//
-//  AppCoordinator.swift
-//  AutoTrackApp
-//
-//  Created by Lucas Rodrigues Dias on 27/03/25.
-//
-
-import Foundation

--- a/AutoTrackApp/Commons/AppCoordinator.swift
+++ b/AutoTrackApp/Commons/AppCoordinator.swift
@@ -1,0 +1,8 @@
+//
+//  AppCoordinator.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation

--- a/AutoTrackApp/Commons/Coordinator.swift
+++ b/AutoTrackApp/Commons/Coordinator.swift
@@ -8,26 +8,50 @@
 import Foundation
 import UIKit
 
-///user o protocolo "Coordinator" para implementar nos coordinators
-///aqui teremos abstração de alguns pontos que iremos utilizar
-/// /*viewController*/ -> todo inicio do fluxo necessita de uma UIViewController
-/// entao tente sempre quando "pushar" um fluxo segurar a referencia da view controller do mesmo
-/// /*navigationController*/ -> todo fluxo precisa de uma UINavigationController
-/// entao
+/// O `navigationController` gerencia a pilha de navegação da interface.
+/// Ele é responsável por controlar a navegação entre as telas dentro do fluxo do Coordinator.
+/// A boa pratica é sempre mantermos uma navigation durante um fluxo e evitar inicializar outras demais
+/// Por este motivo temos como argumento no start do `Coordinator` uma UINavigation
+///
+/// Exemplo de uso:
+/// ```
+/// func start(using navigationController: UINavigationController)
+/// self.navigationController = navigationController
+/// navigationController.pushViewController(viewController, animated: true)
+/// ```
 
-/**
-    R é um typealias para LocalizableFiles,
-    ele utiliza o NSLocalizedString para administrarmos os textos dentro do aplicativo
- 
-  `LocalizableFiles` Nome do arquivo de string.
- 
-  `key: String` Chave da string.
-  `args: [CVarArg]` Argumentos para substituição de texto Ex: %@.
- 
-  - *Exemplo da utilização da função:*
-  *         R.default.localized(key: "title")
-  *         R.default.localizedWithArgs(key: "error", args: [error.localizedDescription])
- */
+/// /// O `childCoordinator` é um Coordinator filho que pode ser iniciado dentro deste Coordinator.
+/// Ele é útil para dividir responsabilidades e evitar que um único Coordinator fique muito grande.
+/// Passando no argumento do start a navigation que ja esta inicializada
+///
+/// Exemplo de uso:
+/// ```
+/// let childCoordinator = LoginCoordinator()
+/// childCoordinator = childCoordinator
+/// child.start(using: navigationController)
+/// ```
+
+/// O `viewController` é a tela principal gerenciada por este Coordinator.
+/// Ele é responsável por exibir a interface gráfica correspondente ao fluxo que o Coordinator controla.
+/// Geralmente sempre utilizada no construtor/inicializador do coordinator que esta sendo chamado
+/// E assim seguindo o fluxo implementando a `viewController` dentro do `push` no start como mostrado no exemplo de uso da `navigation`
+///
+/// Exemplo de uso:
+/// ```
+/// let loginViewController = LoginViewController(viewModel: LoginViewModel())
+/// self.viewController = loginViewController
+/// ```
+
+/// `start(using navigationController: UINavigationController)`
+/// Método para iniciar o Coordinator, recebendo um `UINavigationController` para controlar a navegação.
+/// - Parameter navigationController: O controlador de navegação onde as telas serão empilhadas.
+///
+/// Exemplo de uso:
+/// ```
+/// let navigation = UINavigationController()
+/// let loginCoordinator = LoginCoordinator()
+/// loginCoordinator.start(using: navigation)
+/// ```
 
 protocol Coordinator {
     var childCoordinator: Coordinator? { get set }
@@ -35,4 +59,6 @@ protocol Coordinator {
     var navigationController: UINavigationController? { get set }
     
     func start(using navigationController: UINavigationController)
+    
+    ///TODO: `func stop()` implementar futuramente um stop para matar as referencias e evitar retain cycle
 }

--- a/AutoTrackApp/Commons/Coordinator.swift
+++ b/AutoTrackApp/Commons/Coordinator.swift
@@ -1,0 +1,8 @@
+//
+//  Coordinator.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation

--- a/AutoTrackApp/Commons/Coordinator.swift
+++ b/AutoTrackApp/Commons/Coordinator.swift
@@ -6,3 +6,33 @@
 //
 
 import Foundation
+import UIKit
+
+///user o protocolo "Coordinator" para implementar nos coordinators
+///aqui teremos abstração de alguns pontos que iremos utilizar
+/// /*viewController*/ -> todo inicio do fluxo necessita de uma UIViewController
+/// entao tente sempre quando "pushar" um fluxo segurar a referencia da view controller do mesmo
+/// /*navigationController*/ -> todo fluxo precisa de uma UINavigationController
+/// entao
+
+/**
+    R é um typealias para LocalizableFiles,
+    ele utiliza o NSLocalizedString para administrarmos os textos dentro do aplicativo
+ 
+  `LocalizableFiles` Nome do arquivo de string.
+ 
+  `key: String` Chave da string.
+  `args: [CVarArg]` Argumentos para substituição de texto Ex: %@.
+ 
+  - *Exemplo da utilização da função:*
+  *         R.default.localized(key: "title")
+  *         R.default.localizedWithArgs(key: "error", args: [error.localizedDescription])
+ */
+
+protocol Coordinator {
+    var childCoordinator: Coordinator? { get set }
+    var viewController: UIViewController { get set }
+    var navigationController: UINavigationController? { get set }
+    
+    func start(using navigationController: UINavigationController)
+}

--- a/AutoTrackApp/Commons/UIColor+Extensions.swift
+++ b/AutoTrackApp/Commons/UIColor+Extensions.swift
@@ -1,0 +1,8 @@
+//
+//  UIColor+Extensions.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation

--- a/AutoTrackApp/Commons/UIColor+Extensions.swift
+++ b/AutoTrackApp/Commons/UIColor+Extensions.swift
@@ -5,4 +5,39 @@
 //  Created by Lucas Rodrigues Dias on 27/03/25.
 //
 
+import UIKit
 import Foundation
+
+extension UIColor {
+    static let primaryColor = UIColor(hex: "#F0F0F0FF")   ///cinza claro
+    static let grayColor = UIColor(hex: "#A3A3A3FF")      ///cinza escuro
+    static let blackColor = UIColor(hex: "#1F1F1FFF")     ///preto
+    static let whiteColor = UIColor(hex: "#FFFFFFFF")     ///branco
+    static let blueColor = UIColor(hex: "#194AF9FF")      ///azul
+    static let redColor = UIColor(hex: "#E82127FF")       ///vermelho
+    
+    public convenience init?(hex: String) {
+        let r, g, b, a: CGFloat
+        
+        var hexColor = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        if hexColor.count == 6 {
+            hexColor = hexColor + "FF" // Adiciona o valor alfa se não estiver presente
+        }
+        
+        if hexColor.count == 8 {
+            let scanner = Scanner(string: hexColor)
+            var hexNumber: UInt64 = 0
+            
+            if scanner.scanHexInt64(&hexNumber) {
+                r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+                a = CGFloat(hexNumber & 0x000000ff) / 255
+                
+                self.init(red: r, green: g, blue: b, alpha: a)
+                return
+            }
+        }
+        return nil
+    }
+}

--- a/AutoTrackApp/Main/Login/Coordinator/LoginCoordinator.swift
+++ b/AutoTrackApp/Main/Login/Coordinator/LoginCoordinator.swift
@@ -1,0 +1,21 @@
+//
+//  ATLoginCoordinator.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation
+import UIKit
+
+class ATLoginCoordinator: Coordinator {
+    
+    var childCoordinator: Coordinator?
+    var viewController: UIViewController!
+    var navigationController: UINavigationController?
+    
+    func start(using navigationController: UINavigationController) {
+        
+    }
+    
+}

--- a/AutoTrackApp/Main/Login/Coordinator/LoginCoordinator.swift
+++ b/AutoTrackApp/Main/Login/Coordinator/LoginCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  ATLoginCoordinator.swift
+//  LoginCoordinator.swift
 //  AutoTrackApp
 //
 //  Created by Lucas Rodrigues Dias on 27/03/25.
@@ -8,14 +8,21 @@
 import Foundation
 import UIKit
 
-class ATLoginCoordinator: Coordinator {
+class LoginCoordinator: Coordinator {
     
+    var viewController: UIViewController
     var childCoordinator: Coordinator?
-    var viewController: UIViewController!
     var navigationController: UINavigationController?
     
+    init() {
+        let viewModel = LoginViewModel()
+        let viewController = LoginViewController(viewModel: viewModel)
+        self.viewController = viewController
+    }
+    
     func start(using navigationController: UINavigationController) {
-        
+        self.navigationController = navigationController
+        navigationController.pushViewController(viewController, animated: true)
     }
     
 }

--- a/AutoTrackApp/Main/Login/View/LoginViewController.swift
+++ b/AutoTrackApp/Main/Login/View/LoginViewController.swift
@@ -5,4 +5,23 @@
 //  Created by Lucas Rodrigues Dias on 27/03/25.
 //
 
-import Foundation
+import UIKit
+
+class LoginViewController: UIViewController {
+    
+    let viewModel: LoginViewModel
+    
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        view.backgroundColor = .primaryColor
+    }
+    
+}

--- a/AutoTrackApp/Main/Login/View/LoginViewController.swift
+++ b/AutoTrackApp/Main/Login/View/LoginViewController.swift
@@ -1,0 +1,8 @@
+//
+//  LoginViewController.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation

--- a/AutoTrackApp/Main/Login/ViewModel/LoginViewModel.swift
+++ b/AutoTrackApp/Main/Login/ViewModel/LoginViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  LoginViewModel.swift
+//  AutoTrackApp
+//
+//  Created by Lucas Rodrigues Dias on 27/03/25.
+//
+
+import Foundation

--- a/AutoTrackApp/Main/Login/ViewModel/LoginViewModel.swift
+++ b/AutoTrackApp/Main/Login/ViewModel/LoginViewModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+class LoginViewModel {
+    
+    init() {}
+    
+}

--- a/AutoTrackApp/SceneDelegate.swift
+++ b/AutoTrackApp/SceneDelegate.swift
@@ -6,18 +6,28 @@
 //
 
 import UIKit
+import Foundation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    auhsuahsuah
-
+    var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
+        
+        let navigationController = UINavigationController()
+        
+        appCoordinator = AppCoordinator(window)
+        appCoordinator?.start(using: navigationController)
+        
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/AutoTrackApp/SceneDelegate.swift
+++ b/AutoTrackApp/SceneDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    auhsuahsuah
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {


### PR DESCRIPTION
implementei a inicialização do app seguindo a arquitetura definida MVVM-C.

a inicialização acontece via AppCoordinator aonde é inicializado a nossa UINavigationController e assim direcionando para a primeira tela/coordinator do app, o LoginCoordinator/LoginViewController, criei o protocolo Coordinator para promover a abstração na construção dos nossos coordinators aonde deixei bem explicativo o que cada ponto faz dentro da classe `Coordinator`

OBS.: sempre que formos inicializar um coordinator lembra de extender ao protocolo definido.